### PR TITLE
Add IconShowcase

### DIFF
--- a/client/src/components/Module/index.jsx
+++ b/client/src/components/Module/index.jsx
@@ -4,6 +4,7 @@ import SingleMedia from '@Modules/SingleMedia'
 import CaseStudyMockUp from '@Modules/CaseStudyMockUp'
 import TestimonyModule from '@Modules/Testimony'
 import ContentThreeColumns from '@Modules/ContentThreeColumns'
+import IconShowcase from '@Modules/IconShowcase'
 
 // todo refactor to be stateless
 export default class Module extends React.Component {
@@ -20,6 +21,9 @@ export default class Module extends React.Component {
       ),
       ContentfulModuleContentThreeColumns: (attributes) => (
         <ContentThreeColumns {...attributes} />
+      ),
+      ContentfulModuleIconShowcase: (attributes) => (
+        <IconShowcase {...attributes} />
       ),
     }
 

--- a/client/src/modules/IconShowcase/IconBlock.jsx
+++ b/client/src/modules/IconShowcase/IconBlock.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+import * as styles from './iconShowcase.module.scss'
+
+const IconBlock = ({ icon, iconName }) => {
+  const { url } = icon.file
+
+  return (
+    <div className={styles.floating_cards__card}>
+      <figure className={styles.floating_cards__icon}>
+        <img src={url} />
+      </figure>
+
+      <p className={styles.floating_cards__heading_name}>{iconName}</p>
+    </div>
+  )
+}
+
+export default IconBlock

--- a/client/src/modules/IconShowcase/TypeBlock.jsx
+++ b/client/src/modules/IconShowcase/TypeBlock.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import cx from 'classnames'
+
+import * as styles from './iconShowcase.module.scss'
+
+const TypeBlock = ({ iconName }) => {
+  // TODO: dynamically load fonts not in build
+  const font = iconName.toLowerCase().replace(' ', '_') // ex. gotham_bold
+
+  return (
+    <div className={styles.floating_cards__card}>
+      <h3
+        className={cx(styles.floating_cards__heading, styles[`type__${font}`])}
+      >
+        Aa
+      </h3>
+
+      <p className={styles.floating_cards__heading_name}>{iconName}</p>
+    </div>
+  )
+}
+
+export default TypeBlock

--- a/client/src/modules/IconShowcase/iconShowcase.module.scss
+++ b/client/src/modules/IconShowcase/iconShowcase.module.scss
@@ -1,0 +1,261 @@
+@import '../../styles/modifiers/animations';
+@import '../../styles/modifiers/text';
+@import '../../styles/definitions/mixins';
+@import '../../styles/definitions/colors';
+@import '../../styles/definitions/breakpoints';
+
+.no_margin {
+  margin-bottom: 0;
+}
+
+.floating_cards {
+  padding: 85px 0;
+
+  @media #{$phone} {
+    padding: 50px 0 95px;
+  }
+
+  .container {
+    max-width: 985px;
+    display: flex;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+
+    @media #{$phone} {
+      justify-content: flex-start;
+    }
+  }
+
+  &__lead_text {
+    @include fsz(12px);
+    letter-spacing: 2.5px;
+    line-height: 1.33;
+    font-weight: 800;
+    font-family: $primary-family;
+    color: #979797;
+    text-transform: uppercase;
+    margin-bottom: 13px;
+    display: block;
+    width: 100%;
+
+    @media #{$phone} {
+      margin-bottom: 10px;
+    }
+  }
+
+  &__icon {
+    height: 89px;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0 0 6px;
+
+    img {
+      max-width: 100%;
+      height: auto;
+      width: auto;
+    }
+  }
+
+  &__title {
+    @include fsz(132px);
+    font-family: $primary-family;
+    font-weight: bold;
+    letter-spacing: -3px;
+    line-height: 0.91;
+    color: $primary;
+    display: flex;
+    flex-wrap: wrap;
+    margin-right: -3px;
+    width: 100%;
+    @media #{$laptop} {
+      @include fsz(100px);
+    }
+    @media #{$small-screen} {
+      @include fsz(72px);
+    }
+
+    @media #{$phone} {
+      @include fsz(40px);
+      letter-spacing: -0.5px;
+      margin-bottom: 30px;
+    }
+
+    span {
+      display: inline-block;
+      vertical-align: top;
+      letter-spacing: inherit;
+      line-height: inherit;
+      font-family: inherit;
+      white-space: pre;
+      flex: none;
+      margin-right: inherit;
+    }
+  }
+
+  &___items {
+    max-width: 504px;
+    width: 100%;
+    padding-bottom: 24px;
+    margin: -25px -12px 0;
+
+    &.floating_cards___items__large {
+      @media #{$phone} {
+        margin: 0 -13px;
+        width: auto;
+        max-width: 368px;
+      }
+
+      @media screen and (max-width: 389px) {
+        max-width: 338px;
+      }
+
+      .floating_cards__item {
+        @media #{$phone} {
+          width: 50%;
+          padding: 0 13px;
+          float: left;
+          margin-bottom: 26px;
+        }
+
+        &:nth-child(even) {
+          @media #{$phone} {
+            float: right;
+          }
+        }
+
+        .floating_cards__card {
+          @media #{$phone} {
+            height: 156px;
+            width: 156px;
+            padding: 12px 20px;
+          }
+
+          @media screen and (max-width: 389px) {
+            height: 144px;
+            width: 144px;
+          }
+        }
+
+        .floating_cards__heading {
+          @media #{$phone} {
+            text-align: center;
+            @include fsz(90px);
+            margin-bottom: 5px;
+          }
+        }
+      }
+    }
+
+    &.floating_cards___items__small {
+      @media #{$phone} {
+        margin: 0 -13px;
+        width: auto;
+        max-width: inherit;
+      }
+
+      .floating_cards__item {
+        @media #{$phone} {
+          width: 33.33%;
+          padding: 0 13px;
+          margin-bottom: 0;
+        }
+
+        .floating_cards__card {
+          @media #{$phone} {
+            min-height: 90px;
+            width: 90px;
+            height: auto;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            flex-wrap: wrap;
+            flex-direction: column;
+            padding: 23px 0 18px;
+          }
+        }
+
+        .floating_cards__icon {
+          @media #{$phone} {
+            max-width: 30px;
+            max-height: 30px;
+            margin-bottom: 7px;
+          }
+        }
+
+        .floating_cards__heading_name {
+          @media #{$phone} {
+            margin-left: 0;
+          }
+        }
+      }
+    }
+  }
+
+  &__item {
+    width: 33.33%;
+    padding: 0 12px;
+    float: left;
+    margin-top: 24px;
+    transition: 0.38s all ease-out;
+  }
+
+  &__card {
+    background-color: $white;
+    box-shadow: 0 4px 36px -16px rgba(0, 0, 0, 0.25);
+    padding: 23px 19px 18px 18px;
+    height: 144px;
+    width: 144px;
+  }
+
+  &__heading {
+    @include fsz(80px);
+    font-family: $alt-family;
+    font-weight: bold;
+    color: #1c1c1c;
+    text-transform: capitalize;
+    letter-spacing: -2px;
+    margin-right: -2px;
+    margin-bottom: -8px;
+  }
+
+  &__heading_name {
+    @include fsz(12px);
+    font-family: $primary-family;
+    font-weight: 800;
+    color: #979797;
+    text-transform: uppercase;
+    letter-spacing: 2.5px;
+    margin-bottom: 0;
+    margin-left: 6px;
+    line-height: 1.33;
+  }
+}
+
+.type {
+  &__gilroy_bold {
+    font-family: $primary-family;
+    font-weight: bold;
+  }
+  &__gilroy_book {
+    font-family: $primary-family;
+    font-weight: normal;
+  }
+  &__gilroy_light {
+    font-family: $primary-family;
+    font-weight: 300;
+  }
+  &__gotham_bold {
+    font-family: $alt-family;
+    font-weight: bold;
+  }
+  &__gotham_book {
+    font-family: $alt-family;
+    font-weight: normal;
+  }
+  &__gotham_light {
+    font-family: $alt-family;
+    font-weight: 300;
+  }
+}

--- a/client/src/modules/IconShowcase/index.jsx
+++ b/client/src/modules/IconShowcase/index.jsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react'
+import { graphql } from 'gatsby'
+import cx from 'classnames'
+import ScrollTrigger from 'react-scroll-trigger'
+
+import Container from '@Components/Grid/Container'
+import IconBlock from './IconBlock'
+import TypeBlock from './TypeBlock'
+
+import useWindowSize from '@Hooks/useWindowSize'
+import * as styles from './iconShowcase.module.scss'
+
+const maxOffset = 24
+
+const IconShowcase = ({ title, category, iconBox, typeVariant }) => {
+  const [visible, setVisible] = useState(false)
+  const [offset, setOffset] = useState(maxOffset)
+  const { width } = useWindowSize()
+
+  const Block = typeVariant ? TypeBlock : IconBlock
+  const blockSize = typeVariant ? 'large' : 'small'
+
+  const handleScrollProgress = ({ progress }) => {
+    const newOffset = maxOffset - 0.9 * progress * maxOffset
+    setOffset(Math.min(Math.round(newOffset), maxOffset))
+  }
+
+  return (
+    <section className={styles.floating_cards}>
+      <Container className={styles.container}>
+        <ScrollTrigger
+          onEnter={() => setVisible(true)}
+          onProgress={handleScrollProgress}
+        />
+        <p
+          className={cx(
+            styles.floating_cards__lead_text,
+            styles.scroll_reveal,
+            {
+              [styles.fade_in_bottom]: visible,
+            }
+          )}
+        >
+          {category}
+        </p>
+        <h2
+          className={cx(styles.floating_cards__title, styles.scroll_reveal, {
+            [styles.fade_in_bottom]: visible,
+          })}
+        >
+          {title}
+        </h2>
+        <div
+          className={cx(
+            styles.floating_cards___items,
+            styles[`floating_cards___items__${blockSize}`],
+            styles.scroll_reveal,
+            { [styles.fade_in_bottom]: visible }
+          )}
+        >
+          {iconBox.map((block, i) => {
+            // default
+            let paddingTop = offset * (i % 3)
+
+            // type block && phone
+            if (typeVariant && width <= 767) {
+              paddingTop = offset * (i % 2) * 6
+            }
+
+            return (
+              <div
+                className={cx(styles.floating_cards__item)}
+                style={{ paddingTop }}
+              >
+                <Block key={block.id} {...block} />
+              </div>
+            )
+          })}
+        </div>
+      </Container>
+    </section>
+  )
+}
+
+export default IconShowcase
+
+export const query = graphql`
+  fragment IconShowcaseModule on ContentfulModuleIconShowcase {
+    slug
+    title
+    typeVariant
+    category
+    iconBox {
+      id
+      iconName
+      icon {
+        file {
+          url
+        }
+      }
+    }
+  }
+`

--- a/client/src/templates/caseStudy.js
+++ b/client/src/templates/caseStudy.js
@@ -58,6 +58,7 @@ export const query = graphql`
           ...CaseStudyMockUpModule
           ...TestimonyModule
           ...ContentThreeColumnsModule
+          ...IconShowcaseModule
         }
       }
     }


### PR DESCRIPTION
This commit adds the IconShowcase module, which takes a list of Icon
components. If a typeVariant prop is set to true, the module will
render a TypeBlock, otherwise it will render an IconBlock.

The TypeBlock converts the name of the Icon to a className, which
assigns a font-family

A few scrolling animations were also added using the already installed
react-scroll-trigger.