### PR TITLE
Fix case study slider width

### DIFF
--- a/client/src/components/Slider/index.jsx
+++ b/client/src/components/Slider/index.jsx
@@ -33,22 +33,22 @@ const NextArrow = ({ className, style, onClick }) => {
   )
 }
 
-const SliderComponent = ({ children, className }) => {
-  return (
-    <Slider
-      lazyLoad={true}
-      infinite={true}
-      variableWidth={true}
-      speed={500}
-      slidesToShow={1}
-      dots={false}
-      className={className}
-      nextArrow={<NextArrow />}
-      prevArrow={<PrevArrow />}
-    >
-      {children}
-    </Slider>
-  )
-}
+const SliderComponent = React.forwardRef(({ children, className, onReInit}, ref) => (
+  <Slider
+    lazyLoad={true}
+    infinite={true}
+    variableWidth={true}
+    speed={500}
+    slidesToShow={1}
+    dots={false}
+    className={className}
+    ref={ref}
+    onReInit={onReInit}
+    nextArrow={<NextArrow />}
+    prevArrow={<PrevArrow />}
+  >
+    {children}
+  </Slider>
+))
 
 export default SliderComponent

--- a/client/src/modules/Carousel/index.jsx
+++ b/client/src/modules/Carousel/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { graphql } from 'gatsby'
 import uuid from 'uuid'
 
@@ -8,13 +8,27 @@ import Slide from '@Components/Slider/Slide'
 import * as styles from './styles.module.scss'
 
 const CarouselModule = ({ title, slug, slides }) => {
+  const carouselRef = useRef(null)
+  const [height, setHeight] = useState(0)
+  // No need to render during SSR
   if (!isBrowser) {
-    return null;
+    return null
   }
+
+  /**
+   * Set the height of the carousel wrapper to match the inner slick-track height
+   */
+  const onReInit = () => {
+    if (carouselRef.current) {
+      const sliderNode = carouselRef.current.innerSlider.track.node
+      setHeight(sliderNode.clientHeight)
+    }
+  }
+
   return (
-    <section id={slug}>
+    <section id={slug} className={styles.carousel__wrapper} style={{height: `${height}px`}}>
       <div className={styles.container}>
-        <Slider className={'carousel'}>
+        <Slider className={'carousel'} ref={carouselRef} onReInit={onReInit}>
           {slides &&
             slides.map(({ title, description, media }, index) => {
               return (

--- a/client/src/modules/Carousel/styles.module.scss
+++ b/client/src/modules/Carousel/styles.module.scss
@@ -1,4 +1,11 @@
 .container {
   max-width: 100vw;
   overflow: hidden;
+  position: absolute;
+  height: 600px;
+}
+
+.carousel__wrapper {
+  position: relative;
+  height: 600px;
 }


### PR DESCRIPTION
This commit fixes an issue with the slider width on the case studies,
where the width was 10,000 + pixels, due to a flexbox calculation
error.