### PR TITLE
Typography showcase should use icons

### DIFF
--- a/client/src/modules/IconShowcase/IconBlock.jsx
+++ b/client/src/modules/IconShowcase/IconBlock.jsx
@@ -8,7 +8,7 @@ const IconBlock = ({ icon, iconName }) => {
   return (
     <div className={styles.floating_cards__card}>
       <figure className={styles.floating_cards__icon}>
-        <img src={url} />
+        <img src={url} alt={iconName} />
       </figure>
 
       <p className={styles.floating_cards__heading_name}>{iconName}</p>

--- a/client/src/modules/IconShowcase/TypeBlock.jsx
+++ b/client/src/modules/IconShowcase/TypeBlock.jsx
@@ -1,21 +1,15 @@
 import React from 'react'
-import cx from 'classnames'
 
 import * as styles from './iconShowcase.module.scss'
 
-const TypeBlock = ({ iconName }) => {
-  // TODO: dynamically load fonts not in build
-  const font = iconName.toLowerCase().replace(' ', '_') // ex. gotham_bold
+const TypeBlock = ({ icon, iconName }) => {
+  const { url } = icon.file
 
   return (
     <div className={styles.floating_cards__card}>
-      <h3
-        className={cx(styles.floating_cards__heading, styles[`type__${font}`])}
-      >
-        Aa
-      </h3>
-
-      <p className={styles.floating_cards__heading_name}>{iconName}</p>
+      <figure className={styles.floating_cards__icon}>
+        <img src={url} alt={iconName} />
+      </figure>
     </div>
   )
 }


### PR DESCRIPTION
This commit updates the `TypeBlock` component to use the icon image,
instead of trying to render the typeface.