### PR TITLE
Display next post

### DIFF
--- a/client/src/layouts/CoreLayout.js
+++ b/client/src/layouts/CoreLayout.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
+import _ from 'lodash'
 import { useSelector } from 'react-redux'
 
 import { TEMPLATES } from '@Utils/enums'
@@ -9,9 +10,9 @@ import Header from '@Components/Header'
 import Sidebar from '@Components/Sidebar'
 import Drawer from '@Components/Drawer'
 import DrawerTemplate from '@Components/DrawerTemplate'
-import {
-  navigationSelectors,
-} from '@State/ducks/ui/navigation'
+import NextPost from '@Components/NextPost'
+import { navigationSelectors } from '@State/ducks/ui/navigation'
+import { contentSelectors } from '@State/ducks/content'
 
 import '../styles/app.scss'
 import * as styles from './layout.module.scss'
@@ -25,8 +26,16 @@ const CoreLayout = ({
   invertPalette,
 }) => {
   const drawerTemplate = useSelector(navigationSelectors.getDrawerTemplate)
+  const drawer = useSelector(navigationSelectors.getDrawer)
+  const nextPost = useSelector(contentSelectors.getNextPost)
 
-  console.log({ drawerTemplate })
+  const maybeRenderNextPost = ({ isOpen, template, slug }) => {
+    if (isOpen && template === TEMPLATES.Post) {
+
+      return !_.isEmpty(nextPost) && <NextPost nextPost={nextPost} />
+    }
+    return null
+  }
 
   return (
     <div
@@ -38,7 +47,8 @@ const CoreLayout = ({
       <Header invertPalette={invertPalette} />
       <Sidebar
         className={cx({
-          [styles.sidebar__case_study]: drawerTemplate === TEMPLATES['Case Study'],
+          [styles.sidebar__case_study]:
+            drawerTemplate === TEMPLATES['Case Study'],
         })}
       />
       <main className={cx(styles.content_wrapper)}>
@@ -53,6 +63,7 @@ const CoreLayout = ({
               <DrawerTemplate />
             </Drawer>
           )}
+          {maybeRenderNextPost(drawer)}
           {!drawerOpen && children}
         </div>
       </main>

--- a/client/src/state/ducks/content/selectors.js
+++ b/client/src/state/ducks/content/selectors.js
@@ -10,8 +10,19 @@ const getCaseStudyBySlug = (state, slug) => {
   return slug ? state.content.caseStudies.byId[slug] : null;
 }
 
+const getNextPost = (state) => {
+  const slug = state.ui.navigation.drawer.slug;
+  if (slug) {
+    const post = state.content.posts.byId[slug];
+    return state.content.posts.byId[post.next.slug];
+  }
+  
+  return null;
+}
+
 export default {
   getRoleBySlug,
   getPostBySlug,
   getCaseStudyBySlug,
+  getNextPost, 
 }

--- a/client/src/state/utils/ReduxWrapper.js
+++ b/client/src/state/utils/ReduxWrapper.js
@@ -17,6 +17,7 @@ const contentStateFromGraphql = (data, dataObjectKey) => {
     .map((edge) => {
       return {
         ...edge.node,
+        next: edge.next ?? {}
       }
     })
     .forEach((post) => {
@@ -105,6 +106,10 @@ const ReduxWrapper = ({ element }) => (
                 title
               }
               updatedAt
+            }
+            next {
+              slug
+              title
             }
           }
         }


### PR DESCRIPTION
This commit fixes an issue where the next post was no longer being
displayed due to a change in how we were querying posts and content for
populating the drawer.