### PR TITLE
Fixes menu animation

### DIFF
--- a/client/src/components/MenuToggle/toggle.module.scss
+++ b/client/src/components/MenuToggle/toggle.module.scss
@@ -51,12 +51,17 @@
 .menu_bar__container span:nth-child(3) {
   top: 0px;
 }
+.menu_bar__container span:nth-child(2) {
+  .menu_bar__container__open & {
+    opacity: 0;
+  }
+}
 .menu_bar__container span:nth-child(4),
 .menu_bar__container span:nth-child(5),
 .menu_bar__container span:nth-child(6) {
   top: calc(50% - 2px);
   .menu_bar__container__open & {
-    display: none;
+    opacity: 0;
   }
 }
 .menu_bar__container span:nth-child(7),
@@ -64,7 +69,7 @@
 .menu_bar__container span:nth-child(9) {
   top: calc(100% - 4px);
   .menu_bar__container__open & {
-    display: none;
+    opacity: 0;
   }
 }
 .menu_bar__container span:nth-child(3) {
@@ -81,7 +86,7 @@
 .menu_bar__container__open .menu_bar__container span:nth-child(1) {
   width: 20px;
   transform: rotate(45deg);
-  left: 1px;
+  left: -1px;
   top: 7px;
   height: 2px;
   border-radius: 0;
@@ -89,14 +94,12 @@
 .menu_bar__container__open .menu_bar__container span:nth-child(3) {
   width: 20px;
   transform: rotate(-45deg);
-  left: 1px;
+  left: -1px;
   top: 7px;
   height: 2px;
   border-radius: 0;
 }
-.menu_bar__container__open .menu_bar__container span:nth-child(2),
-.menu_bar__container__open .menu_bar__container span:nth-child(5),
-.menu_bar__container__open .menu_bar__container span:nth-child(6) {
+.menu_bar__container__open .menu_bar__container span:nth-child(2) {
   opacity: 0;
 }
 

--- a/client/src/components/Navigation/navigation.module.scss
+++ b/client/src/components/Navigation/navigation.module.scss
@@ -7,6 +7,8 @@
 .navigation_container {
   @media #{$phone} {
     position: fixed;
+    visibility: hidden;
+    opacity: 0;
     width: 100%;
     height: 100%;
     background-color: $gray-light;
@@ -18,12 +20,12 @@
     padding-bottom: 15px;
     align-content: flex-start;
     overflow: auto;
-    display: none;
   }
 
   &.navigation_container__mobile {
     @media #{$phone} {
-      display: block;
+      visibility: visible;
+      opacity: 1;
       padding: 24px 24px 50px;
       box-shadow: 2px 4px 4px 0 rgba(0, 0, 0, 0.14);
       overflow: hidden;


### PR DESCRIPTION
This commit fixes `MenuToggle`'s animations. There are two copies of
`MenuToggle`, one in `Header` and the other in `Navigation`. `Navigation`
overlays the `Header` when the mobile menu is open, and since the mobile
menu is set to `display: none` when closed, there was no initial state to
transition from when opening. This commit fixes that by handling the
menu's display using `visibility` and `opacity`.

This commit also makes slight adjustments to fix the cross's positioning
relative to the square dot menu.