### PR TITLE
Fix Header cutting off Orb

### DIFF
--- a/client/src/modules/Hero/hero.module.scss
+++ b/client/src/modules/Hero/hero.module.scss
@@ -35,6 +35,7 @@
 .hero_block__orb_container {
   canvas {
     transform: rotate(-180deg);
+    top: -80px;
   }
 }
 


### PR DESCRIPTION
This commit moves the orb on the `/careers` page up a bit so it doesn't
look like the Header cuts it off when it moves off the `canvas`.