### PR TITLE
Sync news read times

### DIFF
--- a/client/src/modules/BlogExcerpt/index.jsx
+++ b/client/src/modules/BlogExcerpt/index.jsx
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import { GatsbyImage, getImage } from 'gatsby-plugin-image'
 import { graphql } from 'gatsby'
 import { useDispatch } from 'react-redux'
+import readingTime from 'reading-time'
 
 import urls from '@Utils/urls'
 import { H2 } from '@Components/Typography'
@@ -29,6 +30,7 @@ const BlogExcerpt = ({
   index,
   postSlug,
   title,
+  content,
 }) => {
   const image = getImage(featuredImage)
   const dispatch = useDispatch();
@@ -37,6 +39,8 @@ const BlogExcerpt = ({
     event.preventDefault();
     dispatch(navigationActions.requestOpenDrawer({ template: 'post', slug: postSlug, invertPalette: false }))
    }
+
+  const stats = readingTime(content.raw)
 
   return (
     <article
@@ -55,7 +59,7 @@ const BlogExcerpt = ({
             <p className={style.blogExcerpt__date}>{createdAt}</p>
             <p>
               <span>{renderCategoryString(categories)}</span>
-              <span> — 3 min read</span>
+              <span> — {stats.text}</span>
             </p>
           </div>
           <div
@@ -79,5 +83,8 @@ export const query = graphql`
     }
     slug
     title
+    content {
+      raw
+    }
   }
 `

--- a/client/src/modules/BlogIndex/index.jsx
+++ b/client/src/modules/BlogIndex/index.jsx
@@ -46,6 +46,7 @@ const BlogIndex = ({ className }) => {
           key={node.title}
           postSlug={node.slug}
           title={node.title}
+          content={node.content}
         />
       ))}
     </div>


### PR DESCRIPTION
This commit adds the `content` field to `BlogExcerptQuery` and displays
the `readingTime` in the excerpt to each news article.