### PR TITLE
Wrap news title underline

### DIFF
--- a/client/src/modules/BlogExcerpt/blogExcerpt.module.scss
+++ b/client/src/modules/BlogExcerpt/blogExcerpt.module.scss
@@ -33,7 +33,7 @@ h2 {
 }
 
 .blogExcerptH2 {
-  border-bottom: 1px solid transparent;
+  // border-bottom: 1px solid transparent;
   display: inline-block;
   font-weight: bold;
   margin-bottom: 0.35rem;
@@ -52,7 +52,10 @@ h2 {
 
   &:hover {
     .blogExcerptH2 {
-      border-bottom: 1px solid $green;
+      // border-bottom: 1px solid $green;
+      text-decoration: underline $green;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 5px;
     }
   }
 }

--- a/client/src/modules/BlogExcerpt/index.jsx
+++ b/client/src/modules/BlogExcerpt/index.jsx
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import { GatsbyImage, getImage } from 'gatsby-plugin-image'
 import { graphql } from 'gatsby'
 import { useDispatch } from 'react-redux'
+import { DateTime } from 'luxon'
 
 import urls from '@Utils/urls'
 import { H2 } from '@Components/Typography'
@@ -21,7 +22,7 @@ const renderCategoryString = (categories) => {
 const BlogExcerpt = ({
   className,
   categories,
-  createdAt,
+  updatedAt,
   featuredImage,
   handleMouseHover,
   handleMouseLeave,
@@ -37,6 +38,8 @@ const BlogExcerpt = ({
     event.preventDefault();
     dispatch(navigationActions.requestOpenDrawer({ template: 'post', slug: postSlug, invertPalette: false }))
    }
+  
+  const updatedAtObject = DateTime.fromISO(updatedAt, { zone: 'utc' })
 
   return (
     <article
@@ -52,7 +55,7 @@ const BlogExcerpt = ({
         onMouseOver={handleMouseHover}>
           <div className={cx(style.flexItem)}>
             <H2 text={title} className={cx(style.blogExcerptH2)} />
-            <p className={style.blogExcerpt__date}>{createdAt}</p>
+            <p className={style.blogExcerpt__date}>{updatedAtObject.toFormat('MM.dd.yy')}</p>
             <p>
               <span>{renderCategoryString(categories)}</span>
               <span> — 3 min read</span>
@@ -73,7 +76,7 @@ export default BlogExcerpt
 export const query = graphql`
   fragment BlogExcerptQuery on ContentfulTypeBlogPost {
     category
-    createdAt(formatString: "M.D.YY")
+    updatedAt
     featuredImage {
       gatsbyImageData(width: 300)
     }

--- a/client/src/modules/BlogIndex/index.jsx
+++ b/client/src/modules/BlogIndex/index.jsx
@@ -10,7 +10,7 @@ const BlogIndex = ({ className }) => {
   const query = useStaticQuery(graphql`
     {
       posts: allContentfulTypeBlogPost(
-        sort: { fields: [content___references___createdAt], order: ASC }
+        sort: { fields: updatedAt, order: DESC }
       ) {
         edges {
           node {
@@ -41,7 +41,7 @@ const BlogIndex = ({ className }) => {
           hoveredIndex={hoveredIndex}
           index={idx}
           categories={node.category}
-          createdAt={node.createdAt}
+          updatedAt={node.updatedAt}
           featuredImage={node.featuredImage}
           key={node.title}
           postSlug={node.slug}


### PR DESCRIPTION
This commit replaces `border-bottom` in `BlogExcerpt` with
`text-decoration: underline`.

This commit replaces the `createdAt` field with `updatedAt` in the
`BlogExcerpt`s. Also updates sorting.