### PR TITLE
Fix news animation

### DIFF
--- a/client/src/modules/BlogExcerpt/blogExcerpt.module.scss
+++ b/client/src/modules/BlogExcerpt/blogExcerpt.module.scss
@@ -47,9 +47,9 @@ h2 {
   border-bottom: 1px solid transparent;
   color: $black;
   display: inline-block;
-  margin-bottom: 0.5rem;
+  // margin-bottom: 0.5rem;
   padding: 0;
-  padding-bottom: 2rem;
+  padding-bottom: 2.5rem;
   padding-top: 2rem;
 
   &:hover {

--- a/client/src/modules/BlogExcerpt/blogExcerpt.module.scss
+++ b/client/src/modules/BlogExcerpt/blogExcerpt.module.scss
@@ -7,8 +7,8 @@ $transition: all 0.12s ease-in-out;
 
 .blogExcerpt {
   border-top: 1px solid $gray;
-  padding-bottom: 2rem;
-  padding-top: 2rem;
+  padding-bottom: 0;
+  padding-top: 0;
   padding-left: calc(144px + #{$gutter_desktop});
   padding-right: calc(144px + #{$gutter_desktop});
   width: 100%;
@@ -49,6 +49,8 @@ h2 {
   display: inline-block;
   margin-bottom: 0.5rem;
   padding: 0;
+  padding-bottom: 2rem;
+  padding-top: 2rem;
 
   &:hover {
     .blogExcerptH2 {


### PR DESCRIPTION
This commit moves the `BlogExcerpt` padding to the anchor tag to
reduce the jerkiness of animations when interacting with articles.