### PR TITLE
Fix safari modal fade_in_fwd

### DIFF
--- a/client/src/styles/definitions/_keyframes.scss
+++ b/client/src/styles/definitions/_keyframes.scss
@@ -225,25 +225,25 @@ $transition: all 0.25s ease-in;
  */
  @-webkit-keyframes fade_in_fwd {
   0% {
-    -webkit-transform: translateZ(-80px);
-            transform: translateZ(-80px);
+    // -webkit-transform: translateZ(-80px);
+            // transform: translateZ(-80px);
     opacity: 0;
   }
   100% {
-    -webkit-transform: translateZ(0);
-            transform: translateZ(0);
+    // -webkit-transform: translateZ(0);
+    //         transform: translateZ(0);
     opacity: 1;
   }
 }
 @keyframes fade_in_fwd {
   0% {
-    -webkit-transform: translateZ(-80px);
-            transform: translateZ(-80px);
+    // -webkit-transform: translateZ(-80px);
+            // transform: translateZ(-80px);
     opacity: 0;
   }
   100% {
-    -webkit-transform: translateZ(0);
-            transform: translateZ(0);
+    // -webkit-transform: translateZ(0);
+    //         transform: translateZ(0);
     opacity: 1;
   }
 }


### PR DESCRIPTION
This commit removes the `translateZ` transformation from the `fade_in_fwd`
animation. On Safari, this was causing the overlay to sit over the modal
until the animation was at 100%, leaving the modal grey until the very
end and causing a sudden flash when `translateZ` shifted from -1px to 0px.